### PR TITLE
refactor: use object to pass arguments

### DIFF
--- a/bin/blazepack.js
+++ b/bin/blazepack.js
@@ -55,7 +55,7 @@ if (args.version) {
 
       template = validateNewProject(projectName, template);
 
-      createProject(projectName, template, false, PORT);
+      createProject({ projectName, template, startServer: false, port: PORT });
 
       break;
     }
@@ -65,7 +65,7 @@ if (args.version) {
 
       template = validateNewProject(projectName, template);
 
-      createProject(projectName, template, true, PORT);
+      createProject({ projectName, template, startServer: true, port: PORT });
 
       break;
     }

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ const detectIndent = require('detect-indent');
 const getLatestVersion = require('latest-version');
 const extractZip = require('extract-zip');
 
-async function createProject(projectName, template, startServer, port) {
+async function createProject({ projectName, template, startServer, port }) {
  try {
   const projectPath = path.join(process.cwd(), projectName);
 


### PR DESCRIPTION
## Why?

If we take a look at the function call, we are passing `true` which is unclear for what value we are passing `true`. With object as argument, we can know that `true` value is assigned for starting the server.