### PR TITLE
Fix/exception on reading folder

### DIFF
--- a/bin/blazepack.js
+++ b/bin/blazepack.js
@@ -16,7 +16,7 @@ function validateNewProject(projectName, template) {
   const availableTemplates = ['react', 'preact', 'angular', 'vue2', 'vue3', 'svelte'];
 
   if (!projectName) {
-    logError(`Required argument project name was not provied`);
+    logError(`Required argument project name was not provided`);
 
     process.exit(1);
   }
@@ -44,7 +44,7 @@ if (args.version) {
       const package = args._[1];
 
       if (!package) {
-        logError(`Required argument package name was not provied`);
+        logError(`Required argument package name was not provided`);
 
         process.exit(1);
       }

--- a/src/commands/clone-sandbox/utils.js
+++ b/src/commands/clone-sandbox/utils.js
@@ -26,7 +26,7 @@ function getSandboxFiles(id) {
 }
 
 async function createSandboxFiles(sandboxInfo) {
-  /**
+  /** 
    * Object of all directories
    *
    * For eg:
@@ -71,7 +71,7 @@ async function createSandboxFiles(sandboxInfo) {
     return `${directories[id].title}/${currentDir}`;
   };
 
-  /**
+  /** 
    * Directories object with nested path
    *
    * {
@@ -92,7 +92,7 @@ async function createSandboxFiles(sandboxInfo) {
     sandboxInfo.title || sandboxInfo.id
   );
 
-  /**
+  /** 
    * Create all directories, recursive: true; forces the directory creation if not present
    */
   Object.keys(directoriesWithPath).forEach(async (dir) => {

--- a/src/commands/clone-sandbox/utils.js
+++ b/src/commands/clone-sandbox/utils.js
@@ -26,7 +26,7 @@ function getSandboxFiles(id) {
 }
 
 async function createSandboxFiles(sandboxInfo) {
-  /** 
+  /**
    * Object of all directories
    *
    * For eg:
@@ -71,7 +71,7 @@ async function createSandboxFiles(sandboxInfo) {
     return `${directories[id].title}/${currentDir}`;
   };
 
-  /** 
+  /**
    * Directories object with nested path
    *
    * {
@@ -92,8 +92,8 @@ async function createSandboxFiles(sandboxInfo) {
     sandboxInfo.title || sandboxInfo.id
   );
 
-  /** 
-   * Create all directories, recursice: true; forces the directory creation if not present
+  /**
+   * Create all directories, recursive: true; forces the directory creation if not present
    */
   Object.keys(directoriesWithPath).forEach(async (dir) => {
     await fs.mkdirSync(`${projectPath}/${directoriesWithPath[dir]}`, {

--- a/src/commands/start-dev-server/index.js
+++ b/src/commands/start-dev-server/index.js
@@ -199,8 +199,8 @@ function startDevServer(directory, port) {
         const relativePath = `/${getPosixPath(path.relative(directory, filePath))}`;
         let fileContent;
 
-        if (event !== "unlink" && event !== "unlinkDir" && event !== "addDir") {
-          fileContent = fs.readFileSync(filePath, "utf-8");
+        if (event !== 'unlink' && event !== 'unlinkDir' && event !== 'addDir') {
+          fileContent = fs.readFileSync(filePath, 'utf-8');
         }
 
         wsServer.clients.forEach(client => {

--- a/src/commands/start-dev-server/index.js
+++ b/src/commands/start-dev-server/index.js
@@ -54,7 +54,7 @@ function startDevServer(directory, port) {
 
 
     filePaths.forEach(filePath => {
-      // we don't want to read unneccessary huge files
+      // we don't want to read unnecessary huge files
       const isExcludedFile = IGNORED_FILES.find(excludedFile => excludedFile.test(filePath));
       const filename = path.basename(filePath);
 
@@ -199,8 +199,8 @@ function startDevServer(directory, port) {
         const relativePath = `/${getPosixPath(path.relative(directory, filePath))}`;
         let fileContent;
 
-        if (event !== 'unlink' && event !== 'unlinkDir') {
-          fileContent = fs.readFileSync(filePath, 'utf-8');
+        if (event !== "unlink" && event !== "unlinkDir" && event !== "addDir") {
+          fileContent = fs.readFileSync(filePath, "utf-8");
         }
 
         wsServer.clients.forEach(client => {


### PR DESCRIPTION
I noticed that when a new folder is created that an exception is thrown in the console.

```
e.g.  (node:41829) UnhandledPromiseRejectionWarning: Error: EISDIR: illegal operation on a directory, read
    at Object.readSync (fs.js:568:3)
    at tryReadSync (fs.js:353:20)
    at Object.readFileSync (fs.js:390:19)
    at FSWatcher.<anonymous> (/Users/<username>/.nvm/versions/node/v12.20.1/lib/node_modules/blazepack/src/commands/start-dev-server/index.js:204:28)
```

This addition fixes the issue.

PS My VS Code 'Code Spell Checker' extension noticed a few typos which I've corrected :)