### PR TITLE
Enhancement: Added `install` alias `i`

### DIFF
--- a/bin/blazepack.js
+++ b/bin/blazepack.js
@@ -92,6 +92,7 @@ if (args.version) {
   }
 
   switch (command) {
+    case 'i':
     case 'add':
     case 'install': {
       const package = args._[1];


### PR DESCRIPTION
Now we can also give `blazepack i <package>`